### PR TITLE
fix(ini-config): Корректная фильтрация логов

### DIFF
--- a/src/ini_config/ini_config.py
+++ b/src/ini_config/ini_config.py
@@ -217,7 +217,6 @@ class IniConfig:
     def __init__(self) -> None:
         self._sections: dict[str, ConfigSection] = {}   # Словарь, содержащий объекты секций
         self._logger = logging.getLogger(__file__.removesuffix('.py'))
-        self._logger.setLevel(logging.DEBUG)
         self._logger.addHandler(logging.NullHandler())
 
     def add_section(


### PR DESCRIPTION
При использовании модуля ini-config совместно
с logging все сообщения из ini-config попадают
в журнал независимо от настроек корневого
логгера.

Теперь логи корректно фильтруются согласно
настройкам корневого логгера.

Closes #1