### PR TITLE
Fixed default values for parameters in logs

### DIFF
--- a/src/ini_config/ini_config.py
+++ b/src/ini_config/ini_config.py
@@ -26,6 +26,7 @@ class Parameter:
     attr_name: str
     param_type: Callable[[Any], Any] = str
     default: Any = None
+    converted_default: Any = None
 
 class ConfigNamespace:
     '''
@@ -159,28 +160,32 @@ class ConfigSection:
         if param_type is bool:
             param_type = self._str_to_bool
 
-        # Проверка типа значения по умолчанию
-        if default is not None:
-            try:
-                default = param_type(default)
-            except:
-                raise ConfigError(
-                    f'Ошибка приведения значения по умолчанию для параметра '
-                    f'{self._section_name}.{param_name} к типу '
-                    f'{param_type.__name__}'
-                )
-
+        # Check if param_type is callable
         if not callable(param_type):
             raise ConfigError(
                 f'Тип параметра {self._section_name}.{param_name} '
                 f'{param_type} не является функцией'
             )
 
+        # Проверка типа значения по умолчанию
+        if default is not None:
+            try:
+                converted_default = param_type(default)
+            except:
+                raise ConfigError(
+                    f'Ошибка приведения значения по умолчанию для параметра '
+                    f'{self._section_name}.{param_name} к типу '
+                    f'{param_type.__name__}'
+                )
+        else:
+            converted_default = None
+
         self._params[param_name] = Parameter(
             param_name = param_name,
             attr_name = attr_name,
             param_type = param_type,
-            default = default
+            default = default,
+            converted_default = converted_default
         )
 
         return self
@@ -338,12 +343,12 @@ class IniConfig:
                         f'Параметр {section_name}.{param.param_name} '
                         'отсутствует или задан неверно'
                     )
-                    if param.default is not None:
-                        val = param.default
+                    if param.converted_default is not None:
+                        val = param.converted_default
                         is_missing = False
                         self._logger.warning(
                             f'{log_msg}, используется значение '
-                            f'по умолчанию : {val}'
+                            f'по умолчанию : {param.default}'
                         )
                     else:
                         self._logger.error(

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,6 +1,7 @@
 import pytest
 from pathlib import Path
 from typing import Callable, Any
+import logging
 
 from conftest import TestCfg
 from ini_config import IniConfig, ConfigError
@@ -405,13 +406,15 @@ def test_attr_name_overrides_attributes(
 
    assert 'является магическим методом Python' in str(err.value)
 
-def test_param_type(
-   dummy_cfg: TestCfg,
-   tmp_path: Path
-) -> None:
+def test_param_type(dummy_cfg: TestCfg) -> None:
 
    dummy_cfg.add_section('main')
-   dummy_cfg.add_param('param_1', 'main', 123, None, None)
+   dummy_cfg.add_param(
+      name = 'param_1',
+      section = 'main',
+      val = 123,
+      type = None # pyright: ignore[reportArgumentType]
+   )
    
    with pytest.raises(ConfigError) as err:
       dummy_cfg.make_parser()
@@ -431,5 +434,26 @@ def test_repeating_attr_names(
 
    assert hasattr(cfg, 'duplicate')
 
+def test_default_value_in_logs(
+      dummy_cfg: TestCfg,
+      tmp_path,
+      caplog
+) -> None:
 
-   
+   def _test_type(val: Any) -> bool:
+      if not val:
+         raise ValueError
+
+      return True
+
+   test_logger = logging.getLogger()
+   test_logger.setLevel(logging.DEBUG)
+
+   dummy_cfg.add_section('main')
+   dummy_cfg.add_param('test_param', 'main', '', _test_type, default = 'test_val') 
+   cfg_file = dummy_cfg.make_file(tmp_path)
+   cfg_parser = dummy_cfg.make_parser()
+   cfg = cfg_parser.parse_file(cfg_file)
+
+   assert hasattr(cfg, 'test_param') and getattr(cfg, 'test_param') == True
+   assert ('используется значение по умолчанию : test_val' in caplog.text)


### PR DESCRIPTION
If parameter had complex type, like _str_to_bool, and used default value, log message with explanation contained already converted value instead of original one in ini file, which can be confusing in some cases.

Now log message displays default value exactly as it is in ini file.

Changes:
- Added new property to Parameter object, which contains original default value from ini file
- Covered by new unit tests

Closes #3