### PR TITLE
fix: handle KeyError while reading empty cfg file

### DIFF
--- a/src/ini_config/ini_config.py
+++ b/src/ini_config/ini_config.py
@@ -357,7 +357,7 @@ class IniConfig:
 
             # Если в секции не осталось необработанных параметров,
             # удаляем ее из объекта configparser
-            if not config[section_name]:
+            if config.has_section(section_name) and not config[section_name]:
                 del config[section_name]
 
         # Проверяем, остались ли после разбора конфигурации

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -476,3 +476,39 @@ def test_default_value_in_logs(dummy_cfg: TestCfg, tmp_path, caplog) -> None:
 
     assert hasattr(cfg, "test_param") and getattr(cfg, "test_param")
     assert "используется значение по умолчанию : test_val" in caplog.text
+
+
+def test_empty_cfg_file(dummy_cfg: TestCfg, tmp_path: Path) -> None:
+
+    cfg_file = tmp_path / "cfg_file"
+    with open(cfg_file, "w"):
+        pass
+
+    dummy_cfg.add_section("main")
+    dummy_cfg.add_param("test_param", "main", "test", str, default="test")
+    cfg_parser = dummy_cfg.make_parser()
+    cfg = cfg_parser.parse_file(cfg_file)
+    assert hasattr(cfg, "test_param") and getattr(cfg, "test_param") == "test"
+
+
+def test_parameter_with_default_val_with_no_section_in_cfg(
+    tmp_path: Path, dummy_cfg: TestCfg
+) -> None:
+
+    cfg_file = tmp_path / "cfg_file"
+    with open(cfg_file, "w") as f:
+        f.write("[main]\ntest_param_1 = test\n")
+
+    dummy_cfg.add_section("main")
+    dummy_cfg.add_param("test_param_1", "main", "test", str)
+    dummy_cfg.add_section("ghost_section")
+    dummy_cfg.add_param(
+        "test_param_2", "ghost_section", "test_val", str, default="test_val"
+    )
+    cfg_parser = dummy_cfg.make_parser()
+    cfg = cfg_parser.parse_file(cfg_file)
+
+    assert getattr(cfg, "test_param_1") == "test"
+    assert (section := getattr(cfg, "ghost_section")) and getattr(
+        section, "test_param_2"
+    ) == "test_val"


### PR DESCRIPTION
If all parameters in a section had default values, and neither they nor their section were present in the cfg file, parsing crashed with a KeyError. This is fixed — now parameters with default values and their sections can be safely omitted from the config file. Add unit tests to cover these scenarios.

Closes #4