### PR TITLE
feat: cfg file is not required with default params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ TODO.md
 build
 debian/ini_config
 .ruff_cache
+.coverage

--- a/src/ini_config/ini_config.py
+++ b/src/ini_config/ini_config.py
@@ -266,10 +266,13 @@ class IniConfig:
         try:
             with open(cfg_file, "r") as f:
                 ini_content = f.read()
-        except FileNotFoundError:
-            raise ConfigError(f"Файл не найден: {cfg_file}")
         except Exception as err:
-            raise ConfigError(f"Ошибка чтения файла {cfg_file}: {err}")
+            cfg_file_read_err = True
+            self._logger.warning(f"Ошибка чтения файла {cfg_file}: {err}")
+            ini_content = ""
+        #            raise ConfigError(f"Ошибка чтения файла {cfg_file}: {err}")
+        else:
+            cfg_file_read_err = False
 
         config = configparser.ConfigParser()
         try:
@@ -277,7 +280,8 @@ class IniConfig:
         except Exception as err:
             raise ConfigError(f"Ошибка разбора файла конфигурации {cfg_file}: {err}")
 
-        self._logger.info("Файл конфигурации успешно прочитан")
+        if not cfg_file_read_err:
+            self._logger.info("Файл конфигурации успешно прочитан")
 
         # Создание пустого объекта конфигурации
         namespace = ConfigNamespace()

--- a/tests/test_config_files.py
+++ b/tests/test_config_files.py
@@ -4,17 +4,21 @@ from pathlib import Path
 import os
 
 
-def test_no_cfg_file() -> None:
+def test_no_cfg_file_with_required_params(caplog) -> None:
     """Тест отстутствия файла конфигурации"""
 
-    config = IniConfig()
+    config_parser = IniConfig()
+    config_parser.add_section("main").add_param("required_param")
+
     with pytest.raises(ConfigError) as err:
-        config.parse_file("not_exists")
+        config_parser.parse_file("not_exists")
 
-    assert err.value.__str__() == "Файл не найден: not_exists"
+    assert err.value.__str__() == "Отсутствует параметр main.required_param"
+
+    assert "Ошибка чтения файла not_exists:" in caplog.text
 
 
-def test_unreadable_cfg_file(tmp_path: Path) -> None:
+def test_unreadable_cfg_file(tmp_path: Path, caplog) -> None:
     """Тест отстутствия прав на чтение файла"""
 
     unreadable_cfg = tmp_path / "unreadable_cfg"
@@ -22,24 +26,32 @@ def test_unreadable_cfg_file(tmp_path: Path) -> None:
         pass
     os.chmod(unreadable_cfg, 0x000)
 
-    config = IniConfig()
+    config_parser = IniConfig()
+    config_parser.add_section("main").add_param("required_param")
+
     with pytest.raises(ConfigError) as err:
-        config.parse_file(str(unreadable_cfg))
+        config_parser.parse_file(unreadable_cfg)
+
+    assert str(err.value) == "Отсутствует параметр main.required_param"
+    assert f"Ошибка чтения файла {unreadable_cfg}:" in caplog.text
+
     os.chmod(unreadable_cfg, 0x777)
-    assert f"Ошибка чтения файла {unreadable_cfg}" in str(err.value)
 
 
-def test_unreadable_cfg_dir(tmp_path: Path) -> None:
+def test_unreadable_cfg_dir(tmp_path: Path, caplog) -> None:
     """Каталог с файлом конфигурации недоступен для чтения"""
 
     unreadable_cfg_dir = tmp_path
     os.chmod(tmp_path, 0x000)
 
-    config = IniConfig()
+    config_parser = IniConfig()
+    config_parser.add_section("main").add_param("required_param")
     with pytest.raises(ConfigError) as err:
-        config.parse_file(str(unreadable_cfg_dir / "cfg_file"))
+        config_parser.parse_file(unreadable_cfg_dir / "cfg_file")
+
+    assert str(err.value) == "Отсутствует параметр main.required_param"
+    assert f"Ошибка чтения файла {unreadable_cfg_dir}/cfg_file" in caplog.text
     os.chmod(tmp_path, 0x777)
-    assert f"Ошибка чтения файла {unreadable_cfg_dir}/cfg_file" in str(err.value)
 
 
 def test_corrupted_cfg_file(tmp_path: Path) -> None:

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -4,7 +4,7 @@ from typing import Callable, Any
 import logging
 
 from conftest import TestCfg
-from ini_config import ConfigError
+from ini_config import ConfigError, IniConfig
 
 
 def test_normal_operation(dummy_cfg: TestCfg, tmp_path: Path) -> None:
@@ -512,3 +512,46 @@ def test_parameter_with_default_val_with_no_section_in_cfg(
     assert (section := getattr(cfg, "ghost_section")) and getattr(
         section, "test_param_2"
     ) == "test_val"
+
+
+def test_no_cfg_files_with_all_defult_params(caplog) -> None:
+
+    cfg_parser = IniConfig()
+    cfg_parser.add_section("main").add_param(
+        "default_param_1", param_type=int, default=1
+    ).add_param("default_param_2", param_type=int, default=2)
+    cfg_parser.add_section("test").add_param(
+        "default_param_3", param_type=int, default=3
+    ).add_param("default_param_4", param_type=int, default=4)
+
+    cfg = cfg_parser.parse_file("not_exists")
+
+    assert "Ошибка чтения файла not_exists:" in caplog.text
+    assert getattr(cfg, "default_param_1") == 1
+    assert getattr(cfg, "default_param_2") == 2
+
+    assert (test_section := getattr(cfg, "test"))
+    assert getattr(test_section, "default_param_3") == 3
+    assert getattr(test_section, "default_param_4") == 4
+
+
+def test_no_section_for_default_params(
+    dummy_cfg: TestCfg, tmp_path: Path, caplog
+) -> None:
+
+    test_logger = logging.getLogger()
+    test_logger.setLevel(logging.DEBUG)
+
+    dummy_cfg.add_section("main")
+    dummy_cfg.add_param("required_param", "main", "required_val", str)
+    cfg_file = dummy_cfg.make_file(tmp_path)
+    cfg_parser = dummy_cfg.make_parser()
+
+    cfg_parser.add_section("test").add_param("default_param", default="default_val")
+
+    cfg = cfg_parser.parse_file(cfg_file)
+
+    assert getattr(cfg, "required_param") == "required_val"
+    assert (test_section := getattr(cfg, "test"))
+    assert getattr(test_section, "default_param") == "default_val"
+    assert f"Секция test не найдена в файле {cfg_file}" in caplog.text


### PR DESCRIPTION
Missing config file caused the parser to crash even if none of the config parameters were required. Now if all parameters have default values, config file is not necessary. Missing config file generates warning log event instead of a critical one and does not raise an exception. Also, if all parameters in section have default values, these parameters and respective section can be safely omitted or commented. Added unit tests to cover described scenarios.

Closes #5