### PR TITLE
chore: added GitHub action for Coveralls

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,9 +62,16 @@ jobs:
         run: |
           pytest --cov=src --cov-report=xml --cov-report=term-missing --cov-fail-under=80
       
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+#      - name: Upload coverage to Codecov
+#        uses: codecov/codecov-action@v3
+#        if: success()
+#        with:
+#          file: ./coverage.xml
+#          fail_ci_if_error: false
+
+      - name: Coveralls GitHub Action
+        uses: coverallsapp/github-action@v2.3.6
         if: success()
         with:
           file: ./coverage.xml
-          fail_ci_if_error: false
+          fail-on-error: false


### PR DESCRIPTION
Enables code coverage analysis with Coveralls in PRs. Denies merge if test coverage drops below defined percentage.